### PR TITLE
Updated tarot cog to embeds; updated tools/crimbed

### DIFF
--- a/crimsobot/cogs/mystery.py
+++ b/crimsobot/cogs/mystery.py
@@ -34,7 +34,20 @@ class Mystery(commands.Cog):
         """This three-card spread is read from left to right to explore your past, present, and future."""
 
         fp, descriptions = await tarot.reading(spread)
-        await ctx.send('\n'.join(descriptions), file=discord.File(fp, 'reading.png'))
+        filename = 'reading.png'
+        f = discord.File(fp, filename)
+
+        embed = c.crimbed(
+            title="{}'s reading".format(ctx.author),
+            descr=None,
+            attachment=filename,
+            footer='Type ">tarot card" for more on a specific card.',
+        )
+
+        for card_tuple in descriptions:
+            embed.add_field(name=card_tuple[0], value='**{}**\n{}'.format(card_tuple[1], card_tuple[2]))
+
+        await ctx.send(file=f, embed=embed)
 
     @tarot.command(name='five', brief='Look deeper into your Reason and Potential.')
     @commands.cooldown(3, 300, commands.BucketType.user)
@@ -44,7 +57,20 @@ class Mystery(commands.Cog):
         The Potential card looks toward the outcome should you change paths."""
 
         fp, descriptions = await tarot.reading(spread)
-        await ctx.send('\n'.join(descriptions), file=discord.File(fp, 'reading.png'))
+        filename = 'reading.png'
+        f = discord.File(fp, filename)
+
+        embed = c.crimbed(
+            title="{}'s reading".format(ctx.author),
+            descr=None,
+            attachment=filename,
+            footer='Type ">tarot card" for more on a specific card.',
+        )
+
+        for card_tuple in descriptions:
+            embed.add_field(name=card_tuple[0], value='**{}**\n{}'.format(card_tuple[1], card_tuple[2]))
+
+        await ctx.send(file=f, embed=embed)
 
     @tarot.command(name='card', brief='Inspect an individual card.')
     async def card(self, ctx: commands.Context) -> None:
@@ -136,15 +162,22 @@ class Mystery(commands.Cog):
         await msg.delete()
 
         card = await Deck.get_card(suit, card_number)
-        description = '\n'.join([
-            '**{}**'.format(card.name.upper()),
-            '**Element:** {}'.format(card.element),
-            '**Upright:** {}'.format(card.description_upright),
-            '**Reversed:** {}'.format(card.description_reversed),
-            '\n{}'.format(card.description_long),
-        ])
+
         fp = await card.get_image_buff()
-        await ctx.send(description, file=discord.File(fp, 'card.png'))
+        filename = 'card.png'
+        f = discord.File(fp, filename)
+
+        embed = c.crimbed(
+            title='**{}**'.format(card.name.upper()),
+            descr='\n'.join([
+                '**Element:** {}'.format(card.element),
+                '**Upright:** {}'.format(card.description_upright),
+                '**Reversed:** {}'.format(card.description_reversed),
+                '\n{}'.format(card.description_long),
+            ]),
+            attachment=filename,
+        )
+        await ctx.send(file=f, embed=embed)
 
 
 def setup(bot: CrimsoBOT) -> None:

--- a/crimsobot/data/tarot/suits.yaml
+++ b/crimsobot/data/tarot/suits.yaml
@@ -1,0 +1,19 @@
+suit: MAJOR_ARCANA
+description: >
+    Beginning with The Fool and ending with The World, these 22 cards represent major archetypes. They indicate great cosmic forces at work. Be especially attentive to what they have to say.
+---
+suit: WANDS
+description: >
+    The Wands are ruled by the element of fire. Their sphere of influence is energy, motivation, will, and passion: that which most deeply animates and ignites the soul.
+---
+suit: PENTACLES
+description: >
+    Ruled by the element of earth. The Pentacles deal with earthly matters: health, finances, the body, the domestic sphere, and one's sense of security.
+---
+suit: CUPS
+description: >
+    The Cups are ruled by the element of water. They preside over matters of the heart. Emotion, relationships, inutition, and mystery are all found within their depths.
+---
+suit: SWORDS
+description: >
+    The Swords are ruled by the element of air. Their main concern is the mind and the intellect. They cut through delusion towards clarity with sometimes unforgiving sharpness.

--- a/crimsobot/utils/tarot.py
+++ b/crimsobot/utils/tarot.py
@@ -35,6 +35,9 @@ from crimsobot.utils.tools import clib_path_join
 """
 
 
+# TODO: descriptions to add to >tarot card embed moved to suits.yaml
+
+
 class Suit(Enum):
     MAJOR_ARCANA = 1
     WANDS = 2
@@ -72,7 +75,7 @@ class Card:
 
         img = Image.open(BytesIO(img_bytes))
         if reverse:
-            img.rotate(180)
+            img = img.rotate(180)
 
         return img
 
@@ -137,11 +140,9 @@ class Deck:
         cls._deck = deck
 
 
-async def reading(spread: str) -> Tuple[Optional[io.BytesIO], List[str]]:
+async def reading(spread: str) -> Tuple[Optional[io.BytesIO], List[Tuple[str, str, str]]]:
     w, h = (200, 326)  # card size
     space = 20  # space between cards
-
-    interpret = []  # type: List[str]
 
     if spread == 'ppf':
         # three cards dealt horizontally
@@ -172,16 +173,20 @@ async def reading(spread: str) -> Tuple[Optional[io.BytesIO], List[str]]:
 
     bg = Image.new('RGBA', bg_size, (0, 0, 0, 0))
 
+    interpretation = []  # type: List[Tuple[str, str, str]]
     for i, card in enumerate(cards):
-        reverse = True if random.random() < 0.1 else False
+        reverse = True if random.random() < 0.12 else False
 
         card_image = await card.get_image(reverse)
         bg.paste(card_image, position[i])
 
-        if not reverse:
-            card_description = card.name + ': ' + card.description_upright
+        if reverse:
+            name = card.name + '\n(Reversed)'
+            descr = card.description_reversed
         else:
-            card_description = card.name + ' (reversed): ' + card.description_reversed
-        interpret.append('**{} ·** {}'.format(position_legend[i], card_description))
+            name = card.name
+            descr = card.description_upright
 
-    return image_to_buffer([bg]), interpret
+        interpretation.append((position_legend[i], name, descr))
+
+    return image_to_buffer([bg]), interpretation


### PR DESCRIPTION
Tarot functions now return embeds. I was mistaken before in thinking that attachments could not be included in embeds. To include an image in an embed, one needs a URL. For attachments, that URL can be `'attachment://[filename]'`.

`/utils/tools.py/crimbed` has been updated to more easily allow image URLS and attachments to be included, and this new functionality is used only in the Tarot cog so far. This update adds only kwargs `image_url` and `attachment` and does not break other functions using `crimbed()`.

This augmented `crimbed()` functionality will be put to use in the Image cog in a future PR.