### PR TITLE
Allow CI on forks

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 name: CI/CD
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Discovered while reviewing #67 that we're not running CI on PRs from forks... according to the Actions docs, this should fix it.