### PR TITLE
Stopgap to prevent spam of `emojiclock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 config.py
 .vscode/settings.json
 .vscode/.ropeproject/objectdb
+df

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ __pycache__/
 config.py
 .vscode/settings.json
 .vscode/.ropeproject/objectdb
-df

--- a/crimsobot/bot.py
+++ b/crimsobot/bot.py
@@ -150,7 +150,9 @@ class CrimsoBOT(commands.Bot):
         cleaner = commands.clean_content(use_nicknames=False)
 
         # respond to ping or randomly talk
-        if self.user in message.mentions or (random.random() < 0.002 and not is_dm):
+        if (message.author.id != self.user.id and
+                self.user in message.mentions or
+                (random.random() < 0.002 and not is_dm)):
             # make it look like bot is typing
             await message.channel.trigger_typing()
             crimsonic = await m.async_wrap(self, m.crimso)

--- a/crimsobot/cogs/text.py
+++ b/crimsobot/cogs/text.py
@@ -36,6 +36,7 @@ class Text(commands.Cog):
         await ctx.send('{}: {}'.format(ctx.message.author.mention, output))
 
     @commands.command(aliases=['xokclock', 'xoktime', 'emojitime'])
+    @commands.cooldown(1, 10, commands.BucketType.user)
     async def emojiclock(self, ctx: commands.Context, *args: str) -> None:
         """Get the time at location (required) in emojis!"""
 


### PR DESCRIPTION
A bug in the `on_message` that has the bot respond to when it is mentioned was having the bot respond to messages it sent itself if that message included a mention. This bug was exploited via the `emojiclock` function. `emojiclock` will allow non-emoji input, and users were using a mention of the bot as the "emoji." This was done without end by certain users, causing the increased load issue.

This fix adds a user cooldown to `emojiclock` as well as disallowing the bot to respond to its own messages when those messages contain a mention of the bot.