### PR TITLE
Don't run pipeline twice on PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,10 @@
 name: CI/CD
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
https://github.com/crimsobot/crimsoBOT/commit/88f1414ce8d9d32a20ba4a04b6871c2d5afe2bc9 introduced a regression in which Actions runs were happening twice for any open PRs.
This revises the triggers to only run on `push` to `master` (which also still runs the deploy) and on any `pull_request` event.