### PR TITLE
Fix >tarot one error

### DIFF
--- a/crimsobot/utils/tarot.py
+++ b/crimsobot/utils/tarot.py
@@ -1,5 +1,3 @@
-import io
-import random
 from enum import Enum
 from io import BytesIO
 from typing import List, Optional, Tuple
@@ -169,14 +167,12 @@ async def reading(spread: str) -> Tuple[Optional[io.BytesIO], List[Tuple[str, st
         position_legend = ['PAST', 'PRESENT', 'FUTURE', 'REASON', 'POTENTIAL']
 
     elif spread == 'one':
-        # a singular card on its own
-        # what is it? present?
         bg_size = (w, h)
         cards = await Deck.get_random_cards(1)
         position = [
             (0, 0)
         ]
-        position_legend = ['']  # just assuming once again
+        position_legend = ['\u200d']
 
     else:
         raise commands.BadArgument('Spread is invalid.')

--- a/crimsobot/utils/tarot.py
+++ b/crimsobot/utils/tarot.py
@@ -1,3 +1,5 @@
+import io
+import random
 from enum import Enum
 from io import BytesIO
 from typing import List, Optional, Tuple


### PR DESCRIPTION
Embed field will now have an invisible character as a name instead of `''`