### PR TITLE
Disallow facts with subject or body of length <1

### DIFF
--- a/crimsobot/cogs/reactions.py
+++ b/crimsobot/cogs/reactions.py
@@ -88,7 +88,7 @@ class Reactions(commands.Cog):
             await ctx.send(embed=error_embed, delete_after=18)
             return
 
-        if not (fact_subject or fact):
+        if len(fact_subject) < 1 or len(fact) < 1:
             await ctx.send(embed=error_embed, delete_after=18)
             return
 

--- a/crimsobot/cogs/reactions.py
+++ b/crimsobot/cogs/reactions.py
@@ -88,7 +88,7 @@ class Reactions(commands.Cog):
             await ctx.send(embed=error_embed, delete_after=18)
             return
 
-        if len(fact_subject) < 1 or len(fact) < 1:
+        if len(fact_subject) < 1 or len(fact) < 2:
             await ctx.send(embed=error_embed, delete_after=18)
             return
 


### PR DESCRIPTION
Facts with subjects of bodies of zero length were being added, and they cannot be accessed or inspected.