### PR TITLE
Fact lb fix

### DIFF
--- a/crimsobot/utils/fact_leaderboard.py
+++ b/crimsobot/utils/fact_leaderboard.py
@@ -77,14 +77,14 @@ class FactLeaderboard:
                     new_subject = ' '.join(words)
 
                 self._embed.add_field(
-                    name='{}. **{}**'.format(place, new_subject if new_subject else leader.subject),
+                    name=f'{place}. **{new_subject if new_subject else leader.subject}**',
                     value=leader.value,
                     inline=False
                 )
 
-        self._embed.set_footer(text='Page {}{}'.format(self.page, self._embed_footer_extra))
+        self._embed.set_footer(text=f'{ctx.guild.name} · Page {self.page}{self._embed_footer_extra}')
 
         return self._embed
 
     def _set_embed_title(self, stat: str) -> None:
-        self._embed.title = 'FACTS! leaderboard: **{}**'.format(stat.upper())
+        self._embed.title = f'FACTS! leaderboard: **{stat.upper()}**'


### PR DESCRIPTION
When the subject of a fact contained a user mention, the subject would not display well on the leaderboard, e.g. '<@123...678>'. These user mention strings are now detected and converted to usernames, e.g. '@username#1234'.