### PR TITLE
Add alias "pay" to give command

### DIFF
--- a/crimsobot/cogs/games.py
+++ b/crimsobot/cogs/games.py
@@ -472,7 +472,7 @@ class Games(commands.Cog):
         )
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.command(aliases=["pay"])
     @commands.cooldown(2, 60*30, commands.BucketType.user)
     async def give(self, ctx: commands.Context, recipient: discord.Member, amount: float) -> None:
         """Give a user up to 1/4 of your crimsoCOIN."""

--- a/crimsobot/cogs/games.py
+++ b/crimsobot/cogs/games.py
@@ -472,7 +472,7 @@ class Games(commands.Cog):
         )
         await ctx.send(embed=embed)
 
-    @commands.command(aliases=["pay"])
+    @commands.command(aliases=['pay'])
     @commands.cooldown(2, 60*30, commands.BucketType.user)
     async def give(self, ctx: commands.Context, recipient: discord.Member, amount: float) -> None:
         """Give a user up to 1/4 of your crimsoCOIN."""


### PR DESCRIPTION
Does exactly what it says on the tin. Adds a single alias to the `give` command for convenience.