### PR TITLE
Tarot rejuvenation

### DIFF
--- a/crimsobot/bot.py
+++ b/crimsobot/bot.py
@@ -7,6 +7,7 @@ from markovify import NewlineText, Text
 
 from config import ADMIN_USER_IDS, BANNED_GUILD_IDS, DM_LOG_CHANNEL_ID, LEARNER_CHANNEL_IDS, LEARNER_USER_IDS
 from crimsobot import db
+from crimsobot.exceptions import NoMatchingTarotCard
 from crimsobot.models.ban import Ban
 from crimsobot.utils import markov as m, tools as c
 
@@ -117,6 +118,11 @@ class CrimsoBOT(commands.Bot):
             error_type = 'INVOKE ERROR'
             traceback_needed = True
             msg_to_user = ':poop: `E R R O R` :poop:'
+
+            if isinstance(error.original, NoMatchingTarotCard):
+                error_type = 'CARD NOT FOUND'
+                traceback_needed = False
+                msg_to_user = "It seems like that tarot card doesn't exist! How curious..."
 
         elif isinstance(error, commands.MissingRequiredArgument):
             error_type = 'MISSING ARGUMENT'

--- a/crimsobot/cogs/mystery.py
+++ b/crimsobot/cogs/mystery.py
@@ -4,7 +4,6 @@ import discord
 from discord.ext import commands
 
 from crimsobot.bot import CrimsoBOT
-from crimsobot.exceptions import NoMatchingTarotCard
 from crimsobot.utils import tarot
 from crimsobot.utils import tools as c
 from crimsobot.utils.tarot import Card, Deck, Suit
@@ -47,12 +46,9 @@ class Mystery(commands.Cog):
             msg = await self.bot.wait_for('message', check=suit_check, timeout=45)
         except asyncio.TimeoutError:
             await prompt_suit.delete()
-            raise NoMatchingTarotCard
+            raise
 
         await prompt_suit.delete()
-
-        if msg is None:
-            raise NoMatchingTarotCard
 
         suit_choice = int(msg.content)
         await msg.delete()
@@ -90,12 +86,9 @@ class Mystery(commands.Cog):
             msg = await self.bot.wait_for('message', check=card_check, timeout=20)
         except asyncio.TimeoutError:
             await prompt_card.delete()
-            raise NoMatchingTarotCard
+            raise
 
         await prompt_card.delete()
-
-        if msg is None:
-            raise NoMatchingTarotCard
 
         card_number = int(msg.content)
         await msg.delete()
@@ -198,7 +191,7 @@ class Mystery(commands.Cog):
         else:
             try:
                 card = await self.prompt_for_single_card(ctx)
-            except NoMatchingTarotCard:  # We timed out, no use letting the error propogate here
+            except asyncio.TimeoutError:
                 return
 
         fp = await card.get_image_buff()

--- a/crimsobot/cogs/mystery.py
+++ b/crimsobot/cogs/mystery.py
@@ -4,16 +4,106 @@ import discord
 from discord.ext import commands
 
 from crimsobot.bot import CrimsoBOT
+from crimsobot.exceptions import NoMatchingTarotCard
 from crimsobot.utils import tarot
 from crimsobot.utils import tools as c
-from crimsobot.utils.tarot import Deck, Suit
+from crimsobot.utils.tarot import Card, Deck, Suit
 
 
 class Mystery(commands.Cog):
     def __init__(self, bot: CrimsoBOT):
         self.bot = bot
 
+    async def prompt_for_single_card(self, ctx: commands.Context) -> Card:
+        # the suits
+        suits = [s for s in Suit]
+        suit_list = []
+        for idx, suit in enumerate(suits):
+            suit_list.append('{}. {}'.format(idx + 1, suit))
+
+        # prompt 1 of 2: choose suit
+        embed = c.crimbed(
+            title='Choose a suit:',
+            descr='\n'.join(suit_list),
+            thumb_name='wizard',
+            footer='Type the number to choose.'
+        )
+        prompt_suit = await ctx.send(embed=embed)
+
+        # define check for suit
+        def suit_check(msg: discord.Message) -> bool:
+            try:
+                valid_choice = 0 < int(msg.content) <= len(suits)
+                in_channel = msg.channel == ctx.message.channel
+                is_author = msg.author == ctx.message.author
+
+                return valid_choice and in_channel and is_author
+
+            except ValueError:
+                return False
+
+        # wait for user to spcify suit
+        try:
+            msg = await self.bot.wait_for('message', check=suit_check, timeout=45)
+        except asyncio.TimeoutError:
+            await prompt_suit.delete()
+            raise NoMatchingTarotCard
+
+        await prompt_suit.delete()
+
+        if msg is None:
+            raise NoMatchingTarotCard
+
+        suit_choice = int(msg.content)
+        await msg.delete()
+
+        # prompt 2 of 2: choose card in suit
+        suit = suits[suit_choice - 1]
+        cards = await Deck.get_cards_in_suit(suit)
+        card_list = []
+        for card in cards:
+            card_list.append('{}. {}'.format(card.number, card.name))
+
+        embed = c.crimbed(
+            title='Choose a card:',
+            descr='\n'.join(card_list),
+            thumb_name='wizard',
+            footer='Type the number to choose.',
+        )
+        prompt_card = await ctx.send(embed=embed)
+
+        # define check for card
+        def card_check(msg: discord.Message) -> bool:
+            try:
+                card_numbers = [c.number for c in cards]
+                valid_choice = int(msg.content) in card_numbers
+                in_channel = msg.channel == ctx.message.channel
+                is_author = msg.author == ctx.message.author
+
+                return valid_choice and in_channel and is_author
+
+            except ValueError:
+                return False
+
+        # wait for user to spcify suit
+        try:
+            msg = await self.bot.wait_for('message', check=card_check, timeout=20)
+        except asyncio.TimeoutError:
+            await prompt_card.delete()
+            raise NoMatchingTarotCard
+
+        await prompt_card.delete()
+
+        if msg is None:
+            raise NoMatchingTarotCard
+
+        card_number = int(msg.content)
+        await msg.delete()
+
+        return await Deck.get_card(suit, card_number)
+
     @commands.group(invoke_without_command=True, brief='Delve into the mysteries of tarot.')
+    @commands.cooldown(3, 300, commands.BucketType.user)
     async def tarot(self, ctx: commands.Context) -> None:
         """Do you seek wisdom and guidance?
         Unveil the Mysteries of the past, the present, and the future with a tarot reading.
@@ -25,7 +115,12 @@ class Mystery(commands.Cog):
             may help coax from you the reason you seek the tarot's guidance.
         """
 
-        # if no subcommand provided, give a three-card reading
+        # if no subcommand is provided, we give a three-card reading.
+        # However, before invoking the command, we make sure that it can be run. If the command cannot be run, can_run
+        # will error and the error will propogate normally. For some odd reason this doesn't catch cooldowns - even
+        # though it should. WHatever. This command has a cooldown so it's fine.
+
+        await self.ppf.can_run(ctx)
         await self.ppf(ctx)
 
     @tarot.command(name='one', brief='Get a single reading.')
@@ -94,95 +189,17 @@ class Mystery(commands.Cog):
         await ctx.send(file=f, embed=embed)
 
     @tarot.command(name='card', brief='Inspect an individual card.')
-    async def card(self, ctx: commands.Context) -> None:
+    @commands.max_concurrency(1, commands.BucketType.user)  # To avoid a 404: Unknown Message & other oddities
+    async def card(self, ctx: commands.Context, *, card_name: str = '') -> None:
         """Inspect an individual tarot card. A longer description is given for each."""
 
-        # the suits
-        suits = [s for s in Suit]
-        suit_list = []
-        for idx, suit in enumerate(suits):
-            suit_list.append('{}. {}'.format(idx + 1, suit))
-
-        # prompt 1 of 2: choose suit
-        embed = c.crimbed(
-            title='Choose a suit:',
-            descr='\n'.join(suit_list),
-            thumb_name='wizard',
-            footer='Type the number to choose.'
-        )
-        prompt_suit = await ctx.send(embed=embed)
-
-        # define check for suit
-        def suit_check(msg: discord.Message) -> bool:
+        if card_name:
+            card = await Deck.get_card_by_name(card_name)  # type: Card
+        else:
             try:
-                valid_choice = 0 < int(msg.content) <= len(suits)
-                in_channel = msg.channel == ctx.message.channel
-                is_author = msg.author == ctx.message.author
-
-                return valid_choice and in_channel and is_author
-
-            except ValueError:
-                return False
-
-        # wait for user to spcify suit
-        try:
-            msg = await self.bot.wait_for('message', check=suit_check, timeout=45)
-        except asyncio.TimeoutError:
-            await prompt_suit.delete()
-            return
-
-        await prompt_suit.delete()
-
-        if msg is None:
-            return
-
-        suit_choice = int(msg.content)
-        await msg.delete()
-
-        # prompt 2 of 2: choose card in suit
-        suit = suits[suit_choice - 1]
-        cards = await Deck.get_cards_in_suit(suit)
-        card_list = []
-        for card in cards:
-            card_list.append('{}. {}'.format(card.number, card.name))
-
-        embed = c.crimbed(
-            title='Choose a card:',
-            descr='\n'.join(card_list),
-            thumb_name='wizard',
-            footer='Type the number to choose.',
-        )
-        prompt_card = await ctx.send(embed=embed)
-
-        # define check for card
-        def card_check(msg: discord.Message) -> bool:
-            try:
-                card_numbers = [c.number for c in cards]
-                valid_choice = int(msg.content) in card_numbers
-                in_channel = msg.channel == ctx.message.channel
-                is_author = msg.author == ctx.message.author
-
-                return valid_choice and in_channel and is_author
-
-            except ValueError:
-                return False
-
-        # wait for user to spcify suit
-        try:
-            msg = await self.bot.wait_for('message', check=card_check, timeout=20)
-        except asyncio.TimeoutError:
-            await prompt_card.delete()
-            return
-
-        await prompt_card.delete()
-
-        if msg is None:
-            return
-
-        card_number = int(msg.content)
-        await msg.delete()
-
-        card = await Deck.get_card(suit, card_number)
+                card = await self.prompt_for_single_card(ctx)
+            except NoMatchingTarotCard:  # We timed out, no use letting the error propogate here
+                return
 
         fp = await card.get_image_buff()
         filename = 'card.png'

--- a/crimsobot/exceptions.py
+++ b/crimsobot/exceptions.py
@@ -1,0 +1,2 @@
+class NoMatchingTarotCard(Exception):
+    pass


### PR DESCRIPTION
This PR makes tarot a little bit nicer.
Changes include:
- Creation of the coveted exceptions.py (which will no doubt be expanded upon later)
- Allowing ``>tarot card`` to be used with the name of a card or the card picking UX. This uses some fancy fuzzy matching so you can afford to make small mistakes in your spelling! Mobile users rejoice.
- Some shuffling of functionality around so that it's tidier.
- Some bug crunching.
