### PR TITLE
Add searchable info WIP

### DIFF
--- a/crimsobot/cogs/reactions.py
+++ b/crimsobot/cogs/reactions.py
@@ -39,7 +39,7 @@ class Reactions(commands.Cog):
         You will need to know that fact's ID """
 
         try:
-            fact_object = await FunFact.get_by_subject(subject.lower().strip(), ctx.guild.id)
+            fact_object = await FunFact.get_random_by_subject(subject.lower().strip(), ctx.guild.id)
         except NoFactsExist:
             embed = c.crimbed(
                 title='OMAN',
@@ -125,7 +125,7 @@ class Reactions(commands.Cog):
         guild = self.bot.get_guild(fact_object.guild_id)
 
         embed = c.crimbed(
-            title=f'FACT INSPECT // ID: {fact_object.uid}' + ' (admin view)' if owner else '',
+            title=f'FACT INSPECT // ID: {fact_object.uid}' + (' (admin view)' if owner else ''),
             descr=None,
             footer='Users with the Manage Messages permission can remove facts using ">fact remove [ID]"',
             thumb_name='nerd',
@@ -143,6 +143,9 @@ class Reactions(commands.Cog):
                     d=fact_object.created_at)
             ),
         ]
+
+        if not owner:
+            field_list.pop(3)  # no need to tell the plebs the server name
 
         for field in field_list:
             embed.add_field(name=field[0], value=field[1], inline=False)
@@ -174,6 +177,41 @@ class Reactions(commands.Cog):
         ])
 
         await ctx.send(return_string)
+
+    @fact.command(name='subject', brief='Get info about a specific subject of facts!')
+    async def subject_info(self, ctx: commands.Context, *, subject: CleanMentions) -> None:
+        """Look up more info about a subject.
+        """
+
+        # clean input
+        user_input = subject.split(';', 1)
+        subject = user_input.pop(0).strip().lower()
+
+        try:
+            fact_object = await FunFact.get_all_by_subject(subject, ctx.guild.id)  # TODO: this only grabs one fact
+            print(fact_object[0].__dict__)
+        except DoesNotExist:
+            embed = c.crimbed(title=None, descr=f'Subject {subject} does not exist (at least not in this server)!')
+            await ctx.send(embed=embed, delete_after=18)
+            return
+
+        embed = c.crimbed(
+            title=f'SUBJECT INSPECT // {subject}',
+            descr=None,
+            footer='Users with the Manage Messages permission can wipe a subject using ">fact wipe [subject]"',
+            thumb_name='nerd',
+            color_name='yellow',
+        )
+
+        field_list = [
+            ('Subject', subject),
+            ('Count', len(fact_object)),
+        ]
+
+        for field in field_list:
+            embed.add_field(name=field[0], value=field[1], inline=False)
+
+        await ctx.send(embed=embed)
 
     @fact.command(name='remove', aliases=['delete'], brief='Remove a fact by ID.')
     @has_guild_permissions(manage_messages=True)

--- a/crimsobot/models/fun_fact.py
+++ b/crimsobot/models/fun_fact.py
@@ -1,5 +1,5 @@
 import random
-from typing import Any, Tuple
+from typing import Any, List, Tuple
 
 from tortoise import fields
 from tortoise.models import Model
@@ -58,7 +58,7 @@ class FunFact(Model):
         return fact
 
     @classmethod
-    async def get_by_subject(cls, subject: str, guild: int) -> 'FunFact':
+    async def get_random_by_subject(cls, subject: str, guild: int) -> 'FunFact':
         all_facts = await FunFact.filter(subject=subject, guild_id=guild).prefetch_related('created_by')
 
         try:
@@ -67,6 +67,12 @@ class FunFact(Model):
             raise NoFactsExist
 
         return fact
+
+    @classmethod
+    async def get_all_by_subject(cls, subject: str, guild: int) -> List['FunFact']:
+        all_facts = await FunFact.filter(subject=subject, guild_id=guild).prefetch_related('created_by')
+
+        return all_facts
 
     @classmethod
     async def get_random(cls, guild: int) -> 'FunFact':


### PR DESCRIPTION
This PR adds some search functionality for bot users. Users will be able to get info embeds for:
- subjects of facts, e.g. number of facts per subject, by using `>fact subject [some subject string]`
- info about facts on their server, e.g. total number of facts, by using `>fact stats`
- maybe some other ideas that I have not yet conjured