### PR TITLE
Only invoke commands if a response is possible

### DIFF
--- a/crimsobot/bot.py
+++ b/crimsobot/bot.py
@@ -211,8 +211,9 @@ class CrimsoBOT(commands.Bot):
         # Get context from message for command invocation and text generation
         ctx = await self.get_context(message, cls=CrimsoContext)
 
-        # process commands
-        await self.invoke(ctx)
+        # Only invoke commands if we can send messages.
+        if ctx.channel.permissions_for(ctx.bot.user).send_messages:
+            await self.invoke(ctx)
 
         # learn from crimso
         if message.author.id in LEARNER_USER_IDS and message.channel.id in LEARNER_CHANNEL_IDS:


### PR DESCRIPTION
This helps avoid issues related to invocations and cooldowns that don't make much sense. It's a small and easy fix.