### PR TITLE
Fix cringo crash at end of turn if DMs can't be sent

### DIFF
--- a/crimsobot/cogs/cringo.py
+++ b/crimsobot/cogs/cringo.py
@@ -369,7 +369,7 @@ class CringoGame():
                 try:
                     await player.user.send(embed=turn_embed)
                 except discord.errors.Forbidden:
-                    self.remove_from_game(player.user.id)
+                    self.remove_from_game(player.user)
 
         # final score + awards time!
         # nerf calculated such that division by zero never attained within player limit


### PR DESCRIPTION
An `AttributeError` in `remove_from_game` breaks the game loop and causes a crash. This fixes that. Mypy should have caught this, but oh well.