### PR TITLE
Allow adding fact without semicolon if body only contains attachments

### DIFF
--- a/crimsobot/cogs/reactions.py
+++ b/crimsobot/cogs/reactions.py
@@ -84,7 +84,7 @@ class Reactions(commands.Cog):
         user_input = something.split(';', 1)
 
         fact_subject = user_input[0].strip().lower()
-        
+
         # if the user entered a subject body, use it
         # and add any attachments
         try:

--- a/crimsobot/cogs/reactions.py
+++ b/crimsobot/cogs/reactions.py
@@ -83,12 +83,20 @@ class Reactions(commands.Cog):
 
         user_input = something.split(';', 1)
 
-        fact_subject = user_input.pop(0).strip().lower()
+        fact_subject = user_input[0].strip().lower()
+        
+        # if the user entered a subject body, use it
+        # and add any attachments
         try:
-            fact = f'{user_input[0].strip()} {links}'
+            fact = f'{user_input[1].strip()} {links}'
         except IndexError:
-            await ctx.send(embed=error_embed, delete_after=18)
-            return
+            # if there is no body but there are still attachments,
+            # use just the attachments as the body
+            if links:
+                fact = links
+            else:
+                await ctx.send(embed=error_embed, delete_after=18)
+                return
 
         if len(fact_subject) < 1 or len(fact) < 2:
             await ctx.send(embed=error_embed, delete_after=18)


### PR DESCRIPTION
Current behavior is fact_add() will pitch a fit if a user tries to add a fact that is only an attachment without including the semicolon. It would make sense to make an exception in this case and let the command go through anyway, because the message contains a valid fact without text in the fact body.