### PR TITLE
Revert "Support hex codes missing the "#""

### DIFF
--- a/crimsobot/cogs/utilities.py
+++ b/crimsobot/cogs/utilities.py
@@ -172,8 +172,6 @@ class Utilities(commands.Cog):
     async def color(self, ctx: commands.Context, hex_value: discord.Colour) -> None:
         """Get color sample from hex value."""
 
-        if hex_value[0] != '#':
-            hex_value = '#' + hex_value
         fp = imagetools.make_color_img(str(hex_value))
         await ctx.send(
             '**' + str(hex_value) + '**',


### PR DESCRIPTION
Reverts crimsobot/crimsoBOT#126
Somehow completely broke the command and now even hex codes that do have the "#" aren't working anymore