### PR TITLE
Query wordle_results by user and return stat embed

### DIFF
--- a/crimsobot/cogs/games.py
+++ b/crimsobot/cogs/games.py
@@ -722,6 +722,13 @@ class Games(commands.Cog):
 
         await ctx.send(embed=embed)
 
+    @commands.command(aliases=['wstats'])
+    async def wordlestats(self, ctx: commands.Context) -> None:
+        """Check your Wordle stats!"""
+
+        embed = await crimsogames.wordle_stat_embed(ctx.message.author)
+        await ctx.send(embed=embed)
+
 
 def setup(bot: CrimsoBOT) -> None:
     bot.add_cog(Games(bot))

--- a/crimsobot/models/wordle_results.py
+++ b/crimsobot/models/wordle_results.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from tortoise import fields
 from tortoise.models import Model
 
@@ -22,6 +24,13 @@ class WordleResults(Model):
         result = WordleResults(user=user, guesses=guesses, word=word)
 
         await result.save()
+
+    @classmethod
+    async def fetch_all_by_user(cls, discord_user: DiscordUser) -> Any:
+        user = await User.get_by_discord_user(discord_user)
+        stat = await WordleResults.filter(user=user)
+
+        return stat
 
     class Meta:
         table = 'wordle_results'


### PR DESCRIPTION
Adds a class method to the `wordle_results` model to filter table by user. Returns results to `utils/games.py` for calculation of stats to place in an embed. Stat calculation includes a nifty little ASCII histogram routine I whipped up just now. Looks good on desktop and mobile, no unexpected line wraps.