### PR TITLE
Image scraper and refactoring!

### DIFF
--- a/crimsobot/bot.py
+++ b/crimsobot/bot.py
@@ -7,7 +7,9 @@ from discord.ext import commands
 from config import ADMIN_USER_IDS, BANNED_GUILD_IDS, DM_LOG_CHANNEL_ID, LEARNER_CHANNEL_IDS, LEARNER_USER_IDS
 from crimsobot import db
 from crimsobot.context import CrimsoContext
-from crimsobot.exceptions import LocationNotFound, NoMatchingTarotCard, NotDirectMessage, StrictInputFailed
+from crimsobot.data.img import IMAGE_RULES
+from crimsobot.exceptions import (LocationNotFound, NoImageFound, NoMatchingTarotCard,
+                                  NotDirectMessage, StrictInputFailed)
 from crimsobot.models.ban import Ban
 from crimsobot.utils import markov as m, tools as c
 
@@ -139,6 +141,11 @@ class CrimsoBOT(commands.Bot):
                 error_type = '**not good with location**'
                 traceback_needed = False
                 msg_to_user = f'Location **{error.original.location}** not found.'
+
+            if isinstance(error.original, NoImageFound):
+                error_type = '**NO IMAGE**'
+                traceback_needed = False
+                msg_to_user = f'No image found in {IMAGE_RULES["msg_scrape_limit"]} most recent messages.'
 
         elif isinstance(error, commands.MissingRequiredArgument):
             error_type = 'MISSING ARGUMENT'

--- a/crimsobot/data/img/__init__.py
+++ b/crimsobot/data/img/__init__.py
@@ -12,9 +12,16 @@ with open(_ruleset_path, encoding='utf-8', errors='ignore') as rules_file:
 
 # these are what should be imported by other scripts
 IMAGE_RULES = _ruleset['image']
+URL_CONTAINS = IMAGE_RULES['url_contains']
+
 GIF_RULES = _ruleset['gif']
+
 _EIMG_RULES = _ruleset['eimg']
 EIMG_WIDTH = _EIMG_RULES['width']
+
+AENIMA = _ruleset['aenima']
+LATERALUS = _ruleset['lateralus']
+
 
 # these will be imported by utils/image.py
 color_dict = _EIMG_RULES['palette']

--- a/crimsobot/data/img/rules.yaml
+++ b/crimsobot/data/img/rules.yaml
@@ -1,5 +1,13 @@
 image:
   max_filesize: 8000000
+  msg_scrape_limit: 8
+  url_contains:
+    - .jpg
+    - .jpeg
+    - .png
+    - .webp
+    - .gif
+    - tenor.com/view
 gif:
   cost_per_frame: 0.10
   max_frames: 300
@@ -36,5 +44,70 @@ eimg:
     '#000060': 🇪🇺
     '#f8afff': 🐖
     '#ff0000': 🍅
-    '#00ffff': 👗
+    '#004488': 👗
     '#b2ffba': 🍐
+aenima:
+  - Constant overstimulation
+  - Not enough, I need more
+  - I'll keep digging
+  - He had a lot of nothing to say
+  - Ranting and pointing his finger
+  - So long, we wish you well
+  - What's coming through is alive
+  - Consideratly killing me
+  - I am too connected to you
+  - Insecure delusions
+  - Change is coming
+  - Crawling on my belly
+  - Figlio di puttana
+  - You think you're cool, right?
+  - You know I'm involved with black magic?
+  - Vans, 501s, and a dope Beastie T
+  - I've got some ad-vice for you little buddy
+  - Send more money
+  - Eleven is standing still
+  - Moving me with a sound
+  - Under a dead Ohio Sky
+  - Ein halbes Pfund Butter
+  - Ein wenig extra Staußzucker
+  - Und keine Eier
+  - Saw the gap again today
+  - I am somewhere I don't wanna be
+  - It will end no other way
+  - Hey. Hey. Hey. Hey. Hey.
+  - Some say the end is near
+  - Fret for your latte
+  - Dreaming of that fix again
+  - So good to see you once again
+  - Blue as our new second sun
+lateralus:
+  - Saturn ascends
+  - Clutch it like a cornerstone
+  - Wear the grudge like a crown
+  - But I'm still right here
+  - Gonna wait it out
+  - I must keep reminding myself of this
+  - I know the pieces fit
+  - Finding beauty in the dissonance
+  - Between supposed lovers
+  - So familiar and overwhelmingly warm
+  - Embrancing you, this reality here
+  - So wide eyed and hopeful
+  - This holy reality
+  - All this pain is an illusion
+  - Recoginize this as a holy gift
+  - Fat little parasite
+  - Suck me dry
+  - I hope you choke on this
+  - Reaching out to embrace the random
+  - Witness the beauty
+  - Spiral out
+  - Mention this to me
+  - Mention something, mention anything
+  - Watch the weather change
+  - My self-indulgent pitiful hole
+  - It's calling me...
+  - Before I pine away...
+  - I don't have a whole lot of time
+  - They'll triangulate on this position really soon
+  - What we're thinking of as aliens⁠—they're extradimensional beings...

--- a/crimsobot/exceptions.py
+++ b/crimsobot/exceptions.py
@@ -17,3 +17,7 @@ class NotDirectMessage(Exception):
 
 class StopHandler(Exception):
     pass
+
+
+class NoImageFound(Exception):
+    pass

--- a/crimsobot/utils/image.py
+++ b/crimsobot/utils/image.py
@@ -561,7 +561,9 @@ async def process_image(ctx: Context, image: Optional[str], effect: str, arg: Op
     # grab user image and covert to RGBA
     img = await fetch_image(ctx, image)
 
-    if getattr(img, 'is_animated', False):
+    is_gif = getattr(img, 'is_animated', False)
+
+    if is_gif:
         if img.n_frames > GIF_RULES['max_frames']:
             embed = c.crimbed(
                 title='OOF',
@@ -603,20 +605,18 @@ async def process_image(ctx: Context, image: Optional[str], effect: str, arg: Op
                 await crimsogames.win(ctx.guild.me, cost)
                 new_bal = await crimsogames.check_balance(ctx.author)
 
-    is_gif = img.format == 'GIF'
-
-    if is_gif:
-        embed = c.crimbed(
-            title='PLS TO HOLD...',
-            descr='\n'.join([
-                f'Processing GIF for **{ctx.author}**...',
-                f'{img.width} \u2A09 {img.height} pixels · {img.n_frames} frames',
-            ]),
-            footer=f'GIF cost: \u20A2{cost:.2f} · Your balance: \u20A2{bal:.2f} ➡️ \u20A2{new_bal:.2f}',
-            color_name='yellow',
-            thumb_name='wizard',
-        )
-        msg = await ctx.send(embed=embed)
+            # this embed will keep user updated on processing status; will be edited below as it progresses
+            embed = c.crimbed(
+                title='PLS TO HOLD...',
+                descr='\n'.join([
+                    f'Processing GIF for **{ctx.author}**...',
+                    f'{img.width} \u2A09 {img.height} pixels · {img.n_frames} frames',
+                ]),
+                footer=f'GIF cost: \u20A2{cost:.2f} · Your balance: \u20A2{bal:.2f} ➡️ \u20A2{new_bal:.2f}',
+                color_name='yellow',
+                thumb_name='wizard',
+            )
+            msg = await ctx.send(embed=embed)
 
     # original image begins processing
     fp = await process_lower_level(img, effect, arg)

--- a/crimsobot/utils/image.py
+++ b/crimsobot/utils/image.py
@@ -603,18 +603,20 @@ async def process_image(ctx: Context, image: Optional[str], effect: str, arg: Op
                 await crimsogames.win(ctx.guild.me, cost)
                 new_bal = await crimsogames.check_balance(ctx.author)
 
-    embed = c.crimbed(
-        title='PLS TO HOLD...',
-        descr='\n'.join([
-            f'Processing GIF for **{ctx.author}**...',
-            f'{img.width} \u2A09 {img.height} pixels · {img.n_frames} frames',
-        ]),
-        footer=f'GIF cost: \u20A2{cost:.2f} · Your balance: \u20A2{bal:.2f} ➡️ \u20A2{new_bal:.2f}',
-        color_name='yellow',
-        thumb_name='wizard',
-    )
+    is_gif = img.format == 'GIF'
 
-    msg = await ctx.send(embed=embed)
+    if is_gif:
+        embed = c.crimbed(
+            title='PLS TO HOLD...',
+            descr='\n'.join([
+                f'Processing GIF for **{ctx.author}**...',
+                f'{img.width} \u2A09 {img.height} pixels · {img.n_frames} frames',
+            ]),
+            footer=f'GIF cost: \u20A2{cost:.2f} · Your balance: \u20A2{bal:.2f} ➡️ \u20A2{new_bal:.2f}',
+            color_name='yellow',
+            thumb_name='wizard',
+        )
+        msg = await ctx.send(embed=embed)
 
     # original image begins processing
     fp = await process_lower_level(img, effect, arg)
@@ -622,17 +624,20 @@ async def process_image(ctx: Context, image: Optional[str], effect: str, arg: Op
 
     # if file too large to send via Discord, then resize
     while n_bytes > IMAGE_RULES['max_filesize']:
-        embed.title = 'RESIZING...'
-        await msg.edit(embed=embed)
+        if is_gif:
+            embed.title = 'RESIZING...'
+            await msg.edit(embed=embed)
+
         # recursively resize image until it meets Discord filesize limit
         img = Image.open(fp)
         scale = IMAGE_RULES['max_filesize'] / n_bytes
         fp = await process_lower_level(img, 'resize', scale)
         n_bytes = fp.getbuffer().nbytes
 
-    embed.title = 'COMPLETE!'
-    embed.description = f'Processed GIF for **{ctx.author}**!'
-    embed.color = 0x5AC037
-    await msg.edit(embed=embed)
+    if is_gif:
+        embed.title = 'COMPLETE!'
+        embed.description = f'Processed GIF for **{ctx.author}**!'
+        embed.color = 0x5AC037
+        await msg.edit(embed=embed)
 
     return fp, img.format


### PR DESCRIPTION
Alright, lots of changes!

## Image scraper

The main course is the image scraper in `cogs/image.py`. I have added a feature where you can use image commands on a recently posted image, not just an image referenced in the message calling the command. You can now run an image command on an image--upload, link, or within an embed!--that's within the past 8 messages. This scraper comes with a custom exception that will notify the user if an image is not found.

## eimg() refactored once more

In order to allow usage of `>eimg mobile` and `>eimg tablet` in conjunction with the image scraper, I needed to refactor `eimg()` into a command group. This switches the order of input from `>eimg [image] [platform]` to `>eimg [optional:platform] [optional:image]`. This only cost a few lines of code.

## Going yam on YAML

More tunable parameters and reference material that needed to live in `rules.yaml` in `data/img` has been added there.

## Fixed a booboo

[A previous pull request](https://github.com/crimsobot/crimsoBOT/pull/137) led to a really bad booboo: any non-GIF images which were processed through `utils/image.py: process_image()` would have led to an error, because non-GIF PIL images have no attribute `n_frames`! A few conditionals now suppress the embeds which expect `n_frames`.