### PR TITLE
Update map command (see PR notes!)

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -42,5 +42,4 @@ LEARNER_CHANNEL_IDS = {
 
 # Astronomy util API keys
 N2YO_API_KEY = None
-MAPQUEST_API_KEY = None
-BITLY_TOKEN = None
+TOMTOM_API_KEY = None

--- a/crimsobot/exceptions.py
+++ b/crimsobot/exceptions.py
@@ -15,6 +15,10 @@ class LocationNotFound(Exception):
         self.location = location
 
 
+class ZoomNotValid(Exception):
+    pass
+
+
 class NotDirectMessage(Exception):
     pass
 


### PR DESCRIPTION
The `utilities/map` command required an update because both the MapQuest API and the Bitly API had ceased to function; neither are free for use any longer. The command is updated to use the TomTom API, which has a handsome daily allowance of free usage.

The TomTom API more easily allows the user to specify a zoom level, so this functionality has been passed on to the user. From `>help map`:
```
>map <location>

Get a map of a location using its name.
You can also specify a zoom level 1-22.
1 is zoomed out the most; 10 is the default.

Example usage: >map hell; 14
```


This will require that `config.py` be updated, as we have switched from MapQuest to TomTom API. References to `MAPQUEST_API_KEY` are now to `TOMTOM_API_KEY`.