### PR TITLE
Obliterating every discriminator I could find

### DIFF
--- a/crimsobot/cogs/admin.py
+++ b/crimsobot/cogs/admin.py
@@ -46,7 +46,7 @@ class Admin(commands.Cog):
 
         embed = c.crimbed(
             title=None,
-            descr='**{}** has been banned from using crimsoBOT.'.format(discord_user),
+            descr=f'**{discord_user.name}** has been banned from using crimsoBOT.',
             color_name='orange'
         )
 
@@ -72,7 +72,7 @@ class Admin(commands.Cog):
 
         embed = c.crimbed(
             title=None,
-            descr='**{}** has been unbanned from using crimsoBOT.'.format(discord_user),
+            descr=f'**{discord_user.name}** has been unbanned from using crimsoBOT.',
             color_name='yellow'
         )
 
@@ -87,7 +87,7 @@ class Admin(commands.Cog):
         banned_users = []
         for user_id in self.bot.banned_user_ids:
             discord_user = await self.bot.fetch_user(user_id)
-            banned_users.append('· {u.name}#{u.discriminator}'.format(u=discord_user))
+            banned_users.append('· {u.name} ({u.id})'.format(u=discord_user))
 
         if not banned_users:
             banned_users.append('No users are banned... yet')

--- a/crimsobot/cogs/image.py
+++ b/crimsobot/cogs/image.py
@@ -99,7 +99,7 @@ class Image(commands.Cog):
             title=title,
             descr=None,
             attachment=filename,
-            footer='Requested by {}'.format(ctx.author),
+            footer='Requested by {}'.format(ctx.author.name),
         )
 
         await ctx.send(file=f, embed=embed)
@@ -162,7 +162,7 @@ class Image(commands.Cog):
         f = discord.File(fp, filename)
 
         embed = c.crimbed(
-            title='{} booped {}!'.format(ctx.author, mention),
+            title=f'{ctx.author.name} booped {mention.name}!',
             descr=None,
             attachment=filename,
         )

--- a/crimsobot/cogs/reactions.py
+++ b/crimsobot/cogs/reactions.py
@@ -143,7 +143,7 @@ class Reactions(commands.Cog):
         field_list = [
             ('Subject', fact_object.subject),
             ('Body', fact_object.body[:500] + '...' if len(fact_object.body) > 500 else fact_object.body),
-            ('Added by', f'{fact_adder} ({fact_adder.id})'),
+            ('Added by', f'{fact_adder.name} ({fact_adder.id})'),
             ('Server', f'{guild.name} ({guild.id})'),
             (
                 'Added on',

--- a/crimsobot/utils/cringo_leaderboard.py
+++ b/crimsobot/utils/cringo_leaderboard.py
@@ -106,7 +106,7 @@ class CringoLeaderboard:
                 discord_user = await ctx.bot.fetch_user(leader.user_id)
                 place = self._offset + place + 1
                 self._embed.add_field(
-                    name='{}. **{}**'.format(place, str(discord_user)),
+                    name='{}. **{}**'.format(place, str(discord_user.name)),
                     value=leader.value,
                     inline=False
                 )

--- a/crimsobot/utils/fact_leaderboard.py
+++ b/crimsobot/utils/fact_leaderboard.py
@@ -49,7 +49,7 @@ class FactLeaderboard:
         matches = [int(item) for item in re.findall(r'<@(\d+)>', string)]
         for user_id in matches:  # all of these will be match group 1 matches cast to int, so just plain ol' IDs
             user = ctx.bot.get_user(user_id) or await ctx.bot.fetch_user(user_id)
-            string = string.replace(f'<@{user_id}>', f'@{user}', 1)
+            string = string.replace(f'<@{user_id}>', f'@{user.name}', 1)
 
         return string
 

--- a/crimsobot/utils/games.py
+++ b/crimsobot/utils/games.py
@@ -212,7 +212,7 @@ async def guess_stat_embed(user: DiscordUser) -> Embed:
         )
     else:
         embed = c.crimbed(
-            title='GUESSMOJI! stats for {}'.format(user),
+            title='GUESSMOJI! stats for {}'.format(user.name),
             descr=None,
             thumb_name='crimsoCOIN',
             footer='Stat tracking as of {d.year}-{d.month:02d}-{d.day:02d}'.format(d=s.created_at),

--- a/crimsobot/utils/guess_leaderboard.py
+++ b/crimsobot/utils/guess_leaderboard.py
@@ -75,7 +75,7 @@ class GuessLeaderboard:
                 discord_user = await ctx.bot.fetch_user(leader.user_id)
                 place = self._offset + place + 1
                 self._embed.add_field(
-                    name='{}. **{}**'.format(place, str(discord_user)),
+                    name='{}. **{}**'.format(place, str(discord_user.name)),
                     value=leader.value,
                     inline=False
                 )

--- a/crimsobot/utils/image.py
+++ b/crimsobot/utils/image.py
@@ -692,7 +692,7 @@ async def process_image(ctx: Context, image: Optional[str], effect: str, arg: Op
             embed = c.crimbed(
                 title='PLS TO HOLD...',
                 descr='\n'.join([
-                    f'Processing GIF for **{ctx.author}**...',
+                    f'Processing GIF for **{ctx.author.name}**...',
                     f'{img.width} \u2A09 {img.height} pixels · {img.n_frames} frames',
                 ]),
                 footer=f'GIF cost: \u20A2{cost:.2f} · Your balance: \u20A2{bal:.2f} ➡️ \u20A2{new_bal:.2f}',
@@ -720,7 +720,7 @@ async def process_image(ctx: Context, image: Optional[str], effect: str, arg: Op
 
     if is_gif:
         embed.title = 'COMPLETE!'
-        embed.description = f'Processed GIF for **{ctx.author}**!'
+        embed.description = f'Processed GIF for **{ctx.author.name}**!'
         embed.color = 0x5AC037
         await msg.edit(embed=embed)
 

--- a/crimsobot/utils/leaderboard.py
+++ b/crimsobot/utils/leaderboard.py
@@ -55,7 +55,7 @@ class Leaderboard:
                 discord_user = await ctx.bot.fetch_user(leader.user_id)
                 place = self._offset + place + 1
                 self._embed.add_field(
-                    name='{}. **{}**'.format(place, str(discord_user)),
+                    name=f'{place}. **{discord_user.name}**',
                     value=leader.value,
                     inline=False
                 )

--- a/crimsobot/utils/tarot.py
+++ b/crimsobot/utils/tarot.py
@@ -304,7 +304,7 @@ async def tarot_embed(
     f = discord.File(fp, filename)
 
     embed = c.crimbed(
-        title="{}'s reading".format(ctx.author),
+        title=f"{ctx.author.name}'s reading",
         descr=None,
         attachment=filename,
         footer=f'{help_str}\nType ">tarot card" for more on a specific card.',

--- a/crimsobot/utils/wordle.py
+++ b/crimsobot/utils/wordle.py
@@ -195,7 +195,7 @@ async def wordle_stat_embed(user: DiscordUser) -> Embed:
         histogram_string_list = '\n'.join(histogram_strings)
 
         embed = c.crimbed(
-            title=f'WORDLE stats for {user}',
+            title=f'WORDLE stats for {user.name}',
             descr=None,
             thumb_name='wordle',
             footer='Thanks for playing >wordle!',


### PR DESCRIPTION
With the decision to no longer use discriminators, many strings referring to a user (e.g. `discord.User` or `ctx.author`) have a vestigial discriminator of "#0". I have tried to find every instance of this to avoid displaying the vestigial discriminator:
- `discord.User` becomes `discord.User.name`
- `ctx.author` becomes `ctx.author.name`
- Any call to `discord.User.discriminator` is removed