### PR TITLE
Emojistory fixes; few more discrims nixed; oops fixed give/bal commands too

### DIFF
--- a/crimsobot/data/games/rules.yaml
+++ b/crimsobot/data/games/rules.yaml
@@ -26,7 +26,7 @@ cringo:
     4: 9
     6: 9
 emojistory:
-  join_timer: 63
+  join_timer: 90
   minimum_length: 5
   maximum_length: 300
   vote_timer: 45

--- a/crimsobot/handlers/games.py
+++ b/crimsobot/handlers/games.py
@@ -77,10 +77,10 @@ class EmojistorySubmissionHandler(AbstractEventGatherer):
 
             embed = c.crimbed(
                 title=None,
-                descr=f'**{message.author}** joined!',
+                descr='Story submitted!',
             )
 
-            await self.context.send(embed=embed, delete_after=8)
+            await self.context.send(embed=embed, delete_after=5)
 
 
 @must_be_event('on_message')
@@ -110,7 +110,7 @@ class EmojistoryVotingHandler(AbstractEventGatherer):
 
             embed = c.crimbed(
                 title=None,
-                descr=f'**{message.author}** voted.',
+                descr=f'**{message.author.name}** voted.',
             )
 
             await self.context.send(embed=embed, delete_after=8)


### PR DESCRIPTION
(oops, scope creep)

- `>emojistory`: Anonymized submission embed, nixed discriminators
- Transactional commands in `cogs/games` reformatted.
- A few more vestigial discriminators found and removed.