### PR TITLE
Constrained width of each line of help text

### DIFF
--- a/crimsobot/cogs/chat.py
+++ b/crimsobot/cogs/chat.py
@@ -71,7 +71,7 @@ class Chat(commands.Cog):
 
     @commands.command(aliases=['monty'])
     async def montyward(self, ctx: commands.Context) -> None:
-        """Monty mindfuck!"""
+        """Monty mindfuck! Just try it."""
 
         footer_text = [
             'Those black spots on your bananas? Those are tarantula eggs.',
@@ -94,7 +94,10 @@ class Chat(commands.Cog):
     @commands.command(hidden=True)
     @commands.is_owner()
     async def scrape(self, ctx: commands.Context, place: str = 'here', join: str = 'space', n: int = 10000) -> None:
-        """Scrape messages from channel. >scrape [here/dm/channel_id] [space/newline]."""
+        """Scrape messages from channel. 
+        
+        >scrape [here/dm/channel_id] [space/newline]
+        """
 
         if ctx.message.author.id not in ADMIN_USER_IDS | SCRAPER_USER_IDS:
             return

--- a/crimsobot/cogs/chat.py
+++ b/crimsobot/cogs/chat.py
@@ -94,8 +94,8 @@ class Chat(commands.Cog):
     @commands.command(hidden=True)
     @commands.is_owner()
     async def scrape(self, ctx: commands.Context, place: str = 'here', join: str = 'space', n: int = 10000) -> None:
-        """Scrape messages from channel. 
-        
+        """Scrape messages from channel.
+
         >scrape [here/dm/channel_id] [space/newline]
         """
 

--- a/crimsobot/cogs/cringo.py
+++ b/crimsobot/cogs/cringo.py
@@ -489,13 +489,20 @@ class Cringo(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @commands.command(aliases=['stats', 'cstats'])
+    @commands.command(aliases=['stats', 'cstats'], brief='Check your CRINGO! stats!')
     async def cringostats(self, ctx: commands.Context, whose: Optional[discord.Member] = None) -> None:
         """Check your or someone else's CRINGO! stats!
+
         Stats will not be counted for incomplete games.
-        Wins are counted only for games with two or more players.
-        Expected average score and lines/game were found via Monte Carlo simulation (n=2.16 million).
-        Expected matches/game and full cards are exact values.
+        Wins are counted only for games with 2+ players.
+
+        Found via Monte Carlo simulation (n = 2,160,000):
+        • Expected average score
+        • Expected lines/game
+
+        Exact values:
+        • Expected matches/game
+        • Expected full cards
         """
 
         if not whose:

--- a/crimsobot/cogs/image.py
+++ b/crimsobot/cogs/image.py
@@ -104,13 +104,20 @@ class Image(commands.Cog):
 
         await ctx.send(file=f, embed=embed)
 
-    @commands.command(aliases=['acidify'])
+    @commands.command(aliases=['acidify'], brief='A funky image breaker.')
     @commands.cooldown(2, 10, commands.BucketType.guild)
     @shared_max_concurrency(eface_bucket)
     async def acid(self, ctx: commands.Context, number_of_hits: int, image: Optional[str] = None) -> None:
         """
-        1-3 hits only. Can use image link, attachment, mention, emoji, previous message, or reply to message with an
-        image.
+        1-3 hits only. Pace yourself.
+
+        The image input can be:
+         - image link
+         - attachment
+         - user mention
+         - emoji
+         - image in previous message
+         - a reply to message with an image
         """
 
         # exception handling
@@ -153,8 +160,10 @@ class Image(commands.Cog):
             await ctx.message.author.send(line)
             await asyncio.sleep(1)
 
-    @commands.command(brief='Boop the snoot! Must mention someone to boop.')
+    @commands.command(brief='Mention someone to boop!')
     async def boop(self, ctx: commands.Context, mention: discord.Member) -> None:
+        """Mention a user (or use their username) to give them a boop!"""
+
         fp = await imagetools.make_boop_img(ctx.author.display_name, mention.display_name)
 
         # filename and file
@@ -172,7 +181,13 @@ class Image(commands.Cog):
     @commands.command(brief='Caption an image!')
     async def caption(self, ctx: commands.Context, *, caption_text: str, image: Optional[str] = None) -> None:
         """
-        The [image] can be a link, upload, user mention (for avatar), an image in a previous message, or from a reply.
+        The image input can be:
+         - image link
+         - attachment
+         - user mention
+         - emoji
+         - image in previous message
+         - a reply to message with an image
 
         You can add your own line breaks, eg:
 
@@ -268,9 +283,21 @@ class Image(commands.Cog):
     @shared_max_concurrency(eface_bucket)
     async def eimg(self, ctx: commands.Context, image: Optional[str] = None, platform: str = 'desktop') -> None:
         """
-        Convert image to emojis!
-        Use ">eimg mobile" or ">eimg tablet" for a smaller image.
-        Works best with images with good contrast and larger features.
+        Convert an image to emojis!
+
+        Works best with images with
+        • good contrast
+        • large features
+
+        The image input can be:
+         - image link
+         - attachment
+         - user mention
+         - emoji
+         - image in previous message
+         - a reply to message with an image
+
+        Use "mobile" or "tablet" for a smaller output.
         """
 
         if image is None:
@@ -324,7 +351,16 @@ class Image(commands.Cog):
 
     @commands.command()
     async def needban(self, ctx: commands.Context, image: Optional[str] = None) -> None:
-        """SOMEONE needs BAN. User mention, attachment, link, emoji, an image in a previous message, or from a reply."""
+        """SOMEONE needs BAN.
+
+        The image input can be:
+         - image link
+         - attachment
+         - user mention
+         - emoji
+         - image in previous message
+         - a reply to message with an image
+        """
 
         if image is None:
             image = await self.get_previous_image(ctx)  # will be a URL
@@ -336,7 +372,15 @@ class Image(commands.Cog):
     @commands.command()
     async def needping(self, ctx: commands.Context, image: Optional[str] = None) -> None:
         """
-        SOMEONE needs PING. User mention, attachment, link, emoji, an image in a previous message, or from a reply.
+        SOMEONE needs PING.
+
+        The image input can be:
+         - image link
+         - attachment
+         - user mention
+         - emoji
+         - image in previous message
+         - a reply to message with an image
         """
 
         if image is None:
@@ -348,7 +392,16 @@ class Image(commands.Cog):
 
     @commands.command(aliases=['verpingt'])
     async def pingbadge(self, ctx: commands.Context, image: Optional[str] = None) -> None:
-        """Add Discord notification badge to an image."""
+        """Add Discord ping badge to an image.
+
+        The image input can be:
+         - image link
+         - attachment
+         - user mention
+         - emoji
+         - image in previous message
+         - a reply to message with an image
+        """
 
         if image is None:
             image = await self.get_previous_image(ctx)  # will be a URL
@@ -393,7 +446,16 @@ class Image(commands.Cog):
 
     @commands.command()
     async def xokked(self, ctx: commands.Context, image: Optional[str] = None) -> None:
-        """Get xokked! User mention, attachment, link, emoji, an image in a previous message, or from a reply."""
+        """Get xokked!
+
+        The image input can be:
+         - image link
+         - attachment
+         - user mention
+         - emoji
+         - image in previous message
+         - a reply to message with an image
+         """
 
         if image is None:
             image = await self.get_previous_image(ctx)  # will be a URL

--- a/crimsobot/cogs/mystery.py
+++ b/crimsobot/cogs/mystery.py
@@ -102,13 +102,17 @@ class Mystery(commands.Cog):
     @commands.cooldown(3, 45, commands.BucketType.user)
     async def tarot(self, ctx: commands.Context, *, user_input: str = '') -> None:
         """Do you seek wisdom and guidance?
-        Unveil the Mysteries of the past, the present, and the future with a tarot reading.
-        A brief meaning of each card appears next to its name.
-        Meditate deeply upon the words of wise crimsoBOT, and all shall become clear...
 
-        You may choose to have a specific question in mind before you ask for your cards.
-        However, taking a reading without a question in mind
-            may help coax from you the reason you seek the tarot's guidance.
+        Unveil the Mysteries with a tarot reading.
+        A brief meaning of each card is given.
+
+        Approach a reading with a specific question.
+        Or take a reading with no question in mind.
+
+        Either way, ponder the wisdom of crimsoBOT.
+        And all shall become clear...
+
+        Begin with '>tarot' for a three-card reading.
         """
 
         # If an argument is passed and a subcommand is not triggered, users are typically trying to look up a card.
@@ -129,7 +133,7 @@ class Mystery(commands.Cog):
     @tarot.command(name='one', aliases=['1'], brief='Get a single-card reading.')
     @commands.cooldown(3, 45, commands.BucketType.user)
     async def one(self, ctx: commands.Context, spread: str = 'one') -> None:
-        """This single-card reading is your answer to any question you may have."""
+        """A single-card reading for simpler questions."""
 
         fp, descriptions = await tarot.reading(spread)
         help_str = self.one.help
@@ -149,29 +153,40 @@ class Mystery(commands.Cog):
     @tarot.command(name='ppf', aliases=['3'], brief='Past, present, and future.')
     @commands.cooldown(3, 45, commands.BucketType.user)
     async def ppf(self, ctx: commands.Context, spread: str = 'ppf') -> None:
-        """Explore the past, present, and future of your query."""
+        """Ponder past, present, and future of deeper queries."""
 
         fp, descriptions = await tarot.reading(spread)
         help_str = self.ppf.help
 
         await tarot.tarot_embed(ctx, fp, descriptions, help_str)
 
-    @tarot.command(name='major3', aliases=['majorthree'], brief='Past, present, and future from the Major Arcana.')
+    @tarot.command(name='major3', aliases=['majorthree'], brief='Past-present-future from the Major Arcana.')
     @commands.cooldown(3, 45, commands.BucketType.user)
     async def major3(self, ctx: commands.Context, spread: str = 'major3') -> None:
-        """Explore the past, present, and future of your query through the Major Arcana."""
+        """For more urgent questions.
+
+        The Major Arcana speaks to powerful archetypes.
+        Limit your reading to only these cards if you wish.
+        """
 
         fp, descriptions = await tarot.reading(spread)
         help_str = self.major3.help
 
         await tarot.tarot_embed(ctx, fp, descriptions, help_str)
 
-    @tarot.command(name='cross', aliases=['5'], brief='Look deeper into your Reason and Potential.')
+    @tarot.command(name='cross', aliases=['5'], brief='Look deeper into Reason and Potential.')
     @commands.cooldown(3, 45, commands.BucketType.user)
     async def five(self, ctx: commands.Context, spread: str = 'five') -> None:
-        """This spread delves deeper into the present, exploring your Reason for seeking guidance.
-        The Future card speaks toward the outcome should you stay on your current path.
-        The Potential card looks toward the outcome should you change paths."""
+        """Delve deeper into the present.
+
+        Exploring your -Reason- for seeking guidance.
+
+        The -Future- card speaks to the outcome...
+        ...should you stay on your current path.
+
+        The -Potential- card looks to the outcome...
+        ...should you change paths.
+        """
 
         fp, descriptions = await tarot.reading(spread)
         help_str = self.five.help
@@ -181,7 +196,12 @@ class Mystery(commands.Cog):
     @tarot.command(name='celtic', aliases=['Celtic'], brief='The Celtic Cross spread.')
     @commands.cooldown(3, 45, commands.BucketType.user)
     async def celtic(self, ctx: commands.Context, spread: str = 'celtic') -> None:
-        """This spread presents the Cross of the current situation and the Pillar of influences."""
+        """For advanced readers.
+
+        This spread presents both
+        • the Cross of the current situation and
+        • the Pillar of influences.
+        """
 
         fp, descriptions = await tarot.reading(spread)
         help_str = self.celtic.help
@@ -191,7 +211,10 @@ class Mystery(commands.Cog):
     @tarot.command(name='card', brief='Inspect an individual card.')
     @commands.max_concurrency(1, commands.BucketType.user)  # To avoid a 404: Unknown Message & other oddities
     async def card(self, ctx: commands.Context, *, card_name: str = '') -> None:
-        """Inspect an individual tarot card. A longer description is given for each."""
+        """Inspect an individual tarot card.
+
+        A longer description is given for each.
+        """
 
         if card_name:
             card = await Deck.get_card_by_name(card_name)  # type: Card

--- a/crimsobot/cogs/reactions.py
+++ b/crimsobot/cogs/reactions.py
@@ -20,8 +20,11 @@ class Reactions(commands.Cog):
 
     @commands.group(aliases=['facts'], invoke_without_command=True, brief='Add and look up facts!')
     async def fact(self, ctx: commands.Context, *, subject: CleanMentions = None) -> None:
-        """Facts is a feature that allows users to add and look up facts in their server.
-        Use >help fact [command] for more info about the subcommands below.
+        """Add and look up facts in their server!
+
+        Check out more about the subcommands below.
+
+        >help fact [command]
         """
 
         if subject:
@@ -35,7 +38,8 @@ class Reactions(commands.Cog):
     @fact.command(name='about', brief='Get a fact about a subject!')
     async def fact_about(self, ctx: commands.Context, *, subject: CleanMentions) -> None:
         """Looks up a random fact about the given subject.
-        If you want to look up a specific fact, use >fact inspect.
+
+        Look up a specific fact with >fact inspect.
         You will need to know that fact's ID """
 
         try:
@@ -62,8 +66,11 @@ class Reactions(commands.Cog):
     @fact.command(name='add', brief='Add a fact!')
     @commands.cooldown(1, 9, commands.BucketType.user)
     async def fact_add(self, ctx: commands.Context, *, something: CleanMentions) -> None:
-        """Add a fact to your server's database of facts. Anyone can add a fact.
-        Fact subjects can be multiple words separated by spaces. Facts can include uploaded files and media.
+        """Add a fact to your server's database of facts!
+
+        Anyone can add a fact.
+        Fact subjects can be multiple words.
+        Facts can include uploaded files and media.
 
         Example usage: >fact add your subject; your fact
         """
@@ -114,8 +121,9 @@ class Reactions(commands.Cog):
 
     @fact.command(name='inspect', brief='Get more info about a specific fact!')
     async def fact_inspect(self, ctx: commands.Context, fact_id: int) -> None:
-        """Use this command to look up information about any fact on your server.
-        You will need a fact's ID, which is at the beginning of each fact when it shows up in the server.
+        """Look up information about any fact on your server.
+
+        You will need a fact's ID number.
         """
 
         # check if owner for server-specific override
@@ -160,8 +168,10 @@ class Reactions(commands.Cog):
     @fact.command(name='random', brief='Random fact from this server!')
     async def fact_random(self, ctx: commands.Context) -> None:
         """Looks up a random fact in the server.
-        If you want to look up a fact about a specific subject, use >fact about [subject].
+
+        This is what happens when you use just '>fact'.
         """
+
         try:
             fact_object = await FunFact.get_random(ctx.guild.id)
         except NoFactsExist:
@@ -187,7 +197,9 @@ class Reactions(commands.Cog):
     @has_guild_permissions(manage_messages=True)
     async def remove_fact(self, ctx: commands.Context, fact_id: int) -> None:
         """Remove a fact by its ID.
-        To use this command, you must have the Manage Messages permission in your server."""
+
+        You must have the Manage Messages permission.
+        """
 
         # check if owner for server-specific override
         owner = ctx.author.id in ADMIN_USER_IDS
@@ -209,8 +221,12 @@ class Reactions(commands.Cog):
                   brief='Remove all facts of a given subject.')
     @has_guild_permissions(manage_messages=True)
     async def remove_subject(self, ctx: commands.Context, *, subject: CleanMentions) -> None:
-        """Remove all facts in a server with the same subject. Useful for removing spam.
-        To use this command, you must have the Manage Messages permission in your server."""
+        """Remove all facts in a server with the same subject.
+
+        Useful for removing spam.
+
+        Must have the Manage Messages permission.
+        """
 
         facts_removed = await FunFact.delete_by_subject(subject, ctx.guild.id)
 
@@ -227,7 +243,9 @@ class Reactions(commands.Cog):
 
     @fact.command(name='lb', aliases=['leaderboard'], brief='Facts leaderboard!')
     async def fact_leaderboard(self, ctx: commands.Context, page: int = 1) -> None:
-        """Leaderboard for most facts by subject (server-specific)."""
+        """Leaderboard for most facts by subject.
+
+        This leaderboard is server-specific."""
 
         lb = FactLeaderboard(page)
         await lb.get_subject_leaders(ctx.guild.id)

--- a/crimsobot/cogs/text.py
+++ b/crimsobot/cogs/text.py
@@ -11,9 +11,11 @@ class Text(commands.Cog):
     def __init__(self, bot: CrimsoBOT):
         self.bot = bot
 
-    @commands.command()
+    @commands.command(brief='Display text as emojis.')
     async def e(self, ctx: commands.Context, *, message: str) -> None:
-        """Convert message to emojis. Character limit ~450."""
+        """Convert a string of text to emojis.
+
+        Character limit ~450."""
 
         message = texttools.block(message)
         lines = c.crimsplit(message, ' ', limit=1900)
@@ -38,7 +40,7 @@ class Text(commands.Cog):
         output = texttools.upsidedown(text)
         await ctx.send('{}: {}'.format(ctx.message.author.mention, output))
 
-    @commands.command(aliases=['xokclock', 'xoktime', 'emojitime'])
+    @commands.command(aliases=['xokclock', 'xoktime', 'emojitime'], brief='Check the time with emojis!')
     @commands.cooldown(1, 10, commands.BucketType.user)
     async def emojiclock(self, ctx: commands.Context, emoji: Optional[AbsurdEmojiConverter], *, location: str) -> None:
         """Get the time at location (required) in emojis!"""

--- a/crimsobot/cogs/utilities.py
+++ b/crimsobot/cogs/utilities.py
@@ -21,13 +21,17 @@ class Utilities(commands.Cog):
     @commands.command(aliases=['vote'], brief='Create a poll!')
     @commands.cooldown(1, 20, commands.BucketType.guild)
     async def poll(self, ctx: commands.Context, *, poll_input: str) -> None:
-        """Make a poll! Use the form of some question;option 1;option 2;etc.
+        """Make a poll!
+
         For example:
 
         >poll What should I eat?;tacos;ramen;the rich
 
-        Polls can have up to 20 choices, but keep in mind Discord's 2000-character message limit.
-        Polls technically never close, but you can >tally the results whenever you like!
+        Polls can have up to 20 choices.
+        Keep in mind Discord's 2000-character limit.
+
+        Polls technically never close.
+        You can >tally the results whenever you like!
         """
 
         poll_pool = [
@@ -82,9 +86,16 @@ class Utilities(commands.Cog):
     @commands.command(aliases=['tally', 'votetally'], brief='Tally results of a poll!')
     @commands.cooldown(1, 20, commands.BucketType.guild)
     async def polltally(self, ctx: commands.Context, poll_id: Optional[str] = None) -> None:
-        """Tally the results of the most recent poll in a channel, or of a previous poll if you give the poll's ID.
-        You can only tally the results of a poll in the same channel as the poll.
-        Tallying a poll does not close the poll; its results can be tallied again if it's not too old."""
+        """Tally the results of a poll!
+
+        Grabs the most recent poll in a channel,
+        Grab a previous poll by using that poll's ID.
+
+        Only works in same channel as the poll.
+
+        Tallying a poll does not close the poll!
+        Results can be tallied again.
+        """
 
         # so this is kinda hacky...
         # first, check channel's message history (backwards from present) for prior polls from bot
@@ -158,7 +169,7 @@ class Utilities(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.command(brief='Ping the bot.')
     @commands.cooldown(1, 10, commands.BucketType.guild)
     async def ping(self, ctx: commands.Context) -> None:
         """Need ping? 10s cooldown after use."""
@@ -169,7 +180,7 @@ class Utilities(commands.Cog):
         ping = (time_out - time_in).microseconds / 1000
         await msg.edit(content='<:ping:569954524932997122>...{:d}ms'.format(int(ping)))
 
-    @commands.command()
+    @commands.command(brief='Get a color sample!')
     async def color(self, ctx: commands.Context, hex_value: Optional[discord.Colour] = None) -> None:
         """Get color sample from hex value, or generate random color if not given input."""
 
@@ -181,15 +192,17 @@ class Utilities(commands.Cog):
             file=discord.File(fp, 'color.jpg')
         )
 
-    @commands.command()
+    @commands.command(brief="Simplify an image's palette.")
     @commands.cooldown(2, 8, commands.BucketType.guild)
     async def palette(self, ctx: commands.Context, number_of_colors: int, link: Optional[str] = None) -> None:
         """
-        Get an image's main colors! Specify # of colors (1-10).
-        • Must follow >palette with an integer between 1 and 10 then either an attached image or a link to an image.
+        Get an image's main colors!
+
+        Must specify # of colors (1-10).
+
         • Best results typically around 5 colors.
-        • SVGs are no.
-        • Images with transparency will sometimes produce a less-than-stellar palette.
+        • SVGs do not work.
+        • Images with transparency may not work.
         """
 
         if not 1 <= number_of_colors <= 10:
@@ -215,9 +228,15 @@ class Utilities(commands.Cog):
 
         await recip.send(message, tts=tts)
 
-    @commands.command()
+    @commands.command(aliases=['bigemoji', 'emoji'], brief='Get big emoji!')
     async def bigmoji(self, ctx: commands.Context, emoji: str) -> None:
-        """Get larger version of either a default or custom emoji!"""
+        """Get a larger version of an emoji!
+
+        Get a 1036 x 1036 version of a default emoji.
+        Get up to a 128x128 version of a custom emoji.
+
+        Works with emojis from other servers.
+        """
 
         path, emoji_type = imagetools.find_emoji_img(emoji)
 
@@ -229,26 +248,38 @@ class Utilities(commands.Cog):
         except Exception:
             await ctx.send('*Not a valid emoji.*')
 
-    @commands.command(brief='Get info on when to see the ISS from the location you search!')
+    @commands.command(brief='When to see the ISS!')
     @commands.cooldown(1, 30, commands.BucketType.user)
     async def iss(self, ctx: commands.Context, *, location: str) -> None:
         """
-        Find out when the International Space Station will be visible to the naked eye from the location you search!
-        Search any location (city, postal code, address, etc).
-        The output is data from heavens-above.com that will tell you where in the sky to look and when (in local time).
+        Want to see the ISS with your naked eye? You can!
 
-        · Start: This is where the ISS becomes visible.
-          It will take a minute or so longer for it to become visible
-          because of the atomosphere and objects (such as trees) on the horizon.
-        · Highest: This is its highest point in the pass. Note the elevation in parenthesis.
-          For reference, 0° is the horizon and 90° is directly overhead.
-        · End: This is where the ISS will pass out of view.
-          In late evening passes, this happens well above the horizon.
-          You just watched the ISS pass into the Earth's shadow!
-        · Brightness: The magnitude is how bright the ISS is expected to be at your location.
-          The lower the number, the brighter the ISS will appear. For example, -3.0 is brighter than 1.0!
+        Search a location by name to find out when.
 
-        (Note: This command works in DM if you want to keep your location private.)
+        The output is data from heavens-above.com.
+        It tells you where in the sky to look (and when).
+
+        START
+        This is where the ISS becomes visible.
+        Be patient; it may take longer.
+        Trees, buildings, and the atmosphere can interfere.
+
+        HIGHEST
+        This is its highest point in the pass.
+        Note the elevation angle in parenthesis.
+        0° is the horizon and 90° is directly overhead.
+
+        END
+        This is where the ISS will pass out of view.
+        In late evening, this happens above the horizon.
+        Because the ISS passes into the Earth's shadow!
+
+        BRIGHTNESS
+        Magnitude is how bright the ISS should be.
+        Lower magnitude = brighter appearance.
+        For example, -3.0 is brighter than 1.0!
+
+        To keep your location private, use this in DMs.
         """
 
         location = location.upper()
@@ -268,7 +299,7 @@ class Utilities(commands.Cog):
             # if i is falsey it must be 0, which means we can send without the header string
             await ctx.send(f'```{string}```' if i else f'{header_string}```{string}```')
 
-    @commands.command(name='map')
+    @commands.command(name='map', brief='Look up a map!')
     @commands.cooldown(3, 10, commands.BucketType.channel)
     async def get_map(self, ctx: commands.Context, *, location: str) -> None:
         """Get a map of a location using its name.


### PR DESCRIPTION
I rewrote all help text such that each line
- fits in a text block without wrapping,
- at minimum Discord app window size (PC/Mac),
- at 100% zoom.

I feel better now.